### PR TITLE
Replace URLs with domains in documentation and code

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,8 +8,8 @@ This URL Categorization Foundry app provides a comprehensive URL filtering solut
 
 The URL Categorization app allows you to:
 
-- Create and manage custom categories of URLs for blocking
-- Deploy firewall rules to block categories of URLs across host groups
+- Create and manage custom categories of domains for blocking
+- Deploy firewall rules to block categories of domains across host groups
 - Import URL categories from CSV files
 - Visualize relationships between categories, rule groups, and host groups
 - Generate analytics on domain blocking patterns
@@ -98,7 +98,7 @@ This application demonstrates advanced usage of Functions, Collections and UI Ex
    - **manage-categories**: Creates or updates categories
    - **manage-relationship**: Creates relationships between categories, rule groups, and hosts
    - **get-relationship**: Retrieves relationship information
-   - **update-rules**: Updates existing rules with new URLs
+   - **update-rules**: Updates existing rules with new domains
 
 2. **Collections for data storage:**
    - **domain**: Stores URLs and category mappings
@@ -126,7 +126,7 @@ This application demonstrates advanced usage of Functions, Collections and UI Ex
 1. Navigate to the **Home** page
 2. Enter a policy name and select a host group
 3. Select the categories you want to block
-4. Click "Preview URLs" to see what will be blocked
+4. Click "Preview domains" to see what will be blocked
 5. Click "Create blocking rule" to deploy the rule
 
 ### Viewing Analytics

--- a/manifest.yml
+++ b/manifest.yml
@@ -1,5 +1,5 @@
 name: Category Blocking
-description: This Foundry app provides a comprehensive URL filtering solution that simplifies firewall rule management through custom categories and automated rule deployment. Built on CrowdStrike's Foundry platform, this application streamlines URL blocking workflows while providing valuable insights into blocking patterns.
+description: This Foundry app provides a comprehensive domain blocking solution that simplifies firewall rule management through custom categories and automated rule deployment. Built on CrowdStrike's Foundry platform, this application streamlines domain blocking workflows while providing valuable insights into blocking patterns.
 logo: images/logo.png
 vendor: CrowdStrike
 vendor_products: []
@@ -39,7 +39,7 @@ ui:
   navigation:
     links:
       - path: /
-        name: URL Blocking
+        name: Category Blocking
         permissions: []
         ref: pages.urlblocking
 api_integrations: []
@@ -167,7 +167,7 @@ functions:
         workflow_integration: null
         permissions: []
       - name: update-rules
-        description: update rules by creating new rule with updates urls
+        description: update rules by creating new rule with updated domains
         method: POST
         api_path: /update-rules
         payload_type: ""

--- a/ui/pages/urlblocking/src/components/navigation.js
+++ b/ui/pages/urlblocking/src/components/navigation.js
@@ -87,7 +87,7 @@ export function TabNavigation({ children }) {
       <style>{customStyles}</style>
       <div style={styles.container}>
         <h1 style={styles.header}>Category Blocking</h1>
-        <p style={styles.subHeader}>Configure URL blocking rules for your host groups</p>
+        <p style={styles.subHeader}>Configure category based blocking rules for your host groups</p>
       </div>
 
       <SlTabGroup
@@ -97,11 +97,11 @@ export function TabNavigation({ children }) {
         <nav style={styles.nav}>
           <div style={styles.tabList}>
             {[
-              { path: '/', label: 'URL Blocking' },
+              { path: '/', label: 'Category Blocking Policy' },
               { path: '/about', label: 'Custom Categories' },
               { path: '/domain-analytics', label: 'Domain Analytics' },
               { path: '/firewall-rules', label: 'Firewall Rules' },
-              { path: '/relationship', label: 'Relationship' }
+              { path: '/relationship', label: 'Relationship Graph' }
             ].map(({ path, label }) => (
               <SlTab
                 key={path}

--- a/ui/pages/urlblocking/src/routes/FirewallRules.js
+++ b/ui/pages/urlblocking/src/routes/FirewallRules.js
@@ -116,7 +116,7 @@ const [hasImported, setHasImported] = useState(false);
                 name: 'urlblock',
                 version: 1
             };
-            
+
             const cloudFunction = falcon.cloudFunction(config);
             const updateResponse = await cloudFunction.path('/update-rules').post({
                 category_name: categoryName,
@@ -128,7 +128,7 @@ const [hasImported, setHasImported] = useState(false);
 
             if (updateResponse.body && updateResponse.body.success) {
                 const results = updateResponse.body.results || [];
-                
+
                 // Update status for each rule group
                 const newStatus = {};
                 results.forEach(result => {
@@ -189,7 +189,7 @@ const [hasImported, setHasImported] = useState(false);
     logMessage(`Adding domain: ${domain} to category: ${selectedCategory}`);
     try {
         setLoading(true);
-        
+
         // First add domain to collection
         const collection = falcon.collection({
             collection: 'domain'
@@ -201,12 +201,12 @@ const [hasImported, setHasImported] = useState(false);
         // Get current category data
         const currentData = await safeReadCollection(collection, safeKey);
         const existingDomains = currentData?.domain || '';
-        
+
         // Add both the original domain and the starred version
         const starredDomain = domain.startsWith('*') ? domain : `*${domain}`;
         const domainsToAdd = `${domain};${starredDomain}`;
-        
-        const updatedDomains = existingDomains 
+
+        const updatedDomains = existingDomains
             ? `${existingDomains};${domainsToAdd}`
             : domainsToAdd;
 
@@ -219,10 +219,10 @@ const [hasImported, setHasImported] = useState(false);
 
         // Then update rules with both domains
         await handleUpdateRules(selectedCategory, domainsToAdd);
-        
+
         // Refresh category details
         await handleCategoryClick(selectedCategory);
-        
+
         setError(null);
         logMessage(`Successfully added domain and starred version, and updated rules`);
 
@@ -234,7 +234,7 @@ const [hasImported, setHasImported] = useState(false);
     }
 };
 
-    
+
 
     const handleImport = async () => {
         logMessage('Starting category import');
@@ -244,7 +244,7 @@ const [hasImported, setHasImported] = useState(false);
                 name: 'urlblock',
                 version: 1
             };
-            
+
             const cloudFunction = falcon.cloudFunction(config);
             const response = await cloudFunction.path('/import-csv').post({
                 collection_name: 'domain'
@@ -314,8 +314,8 @@ const [hasImported, setHasImported] = useState(false);
         </div>
 
         {/* Category Details Dialog */}
-        <SlDialog 
-            open={showDetails} 
+        <SlDialog
+            open={showDetails}
             onSlAfterHide={() => setShowDetails(false)}
             label={`Category Details: ${selectedCategory}`}
             style={{ '--width': '500px' }}
@@ -362,7 +362,7 @@ const [hasImported, setHasImported] = useState(false);
                                     <div className="flex items-center justify-between">
                                         <span className="font-medium">{status.name}</span>
                                         <sl-badge variant={
-                                            status.status === 'Updated successfully' 
+                                            status.status === 'Updated successfully'
                                                 ? 'success'
                                                 : status.status === 'Updating...'
                                                     ? 'info'
@@ -373,7 +373,7 @@ const [hasImported, setHasImported] = useState(false);
                                     </div>
                                     {status.details && (
                                         <div className="mt-2 text-sm text-gray-600">
-                                            {typeof status.details === 'object' 
+                                            {typeof status.details === 'object'
                                                 ? JSON.stringify(status.details, null, 2)
                                                 : status.details
                                             }

--- a/ui/pages/urlblocking/src/routes/about.js
+++ b/ui/pages/urlblocking/src/routes/about.js
@@ -32,7 +32,7 @@ function About() {
         name: 'urlblock',
         version: 1
       };
-      
+
       const cloudFunction = falcon.cloudFunction(config);
 
       console.log('Sending request with:', {
@@ -73,7 +73,7 @@ function About() {
 return (
     <div className="container mx-auto p-4">
         <h2 className="text-lg font-semibold text-black mb-4 text-left">Create custom category</h2>
-      
+
       <div className="space-y-6">
         {/* Category Name Input */}
         <div className="form-group">
@@ -92,7 +92,7 @@ return (
               height: '40px',
               lineHeight: '40px',
     border: '1px solid #B8B7BD',  // Added this line
-    borderRadius: '0'  
+    borderRadius: '0'
             }}
           />
         </div>
@@ -100,12 +100,12 @@ return (
         {/* URLs Input */}
         <div className="form-group">
           <label className="block text-sm font-bold text-black mb-2">
-            URLs (comma-separated)
+            Domains (comma-separated)
           </label>
           <textarea
             value={urls}
             onChange={(e) => setUrls(e.target.value)}
-            placeholder="Enter URLs separated by commas (e.g., example.com, test.com, domain.com)"
+            placeholder="Enter domains separated by commas (e.g., example.com, test.com, domain.com)"
             rows="6"
             className="w-1/2 py-3 px-4 bg-white border border-gray-300 focus:border-gray-400 outline-none font-mono text-sm"
             style={{
@@ -114,7 +114,7 @@ return (
               height: '70px',
               lineHeight: '70px',
     border: '1px solid #B8B7BD',  // Added this line
-    borderRadius: '0'  
+    borderRadius: '0'
             }}
           />
           <p className="mt-2 text-sm text-gray-600">

--- a/ui/pages/urlblocking/src/routes/home.js
+++ b/ui/pages/urlblocking/src/routes/home.js
@@ -33,7 +33,7 @@ function Home() {
   const [isLoading, setIsLoading] = useState(true);
   const [loadingCategories, setLoadingCategories] = useState(true);
   const [isPreviewLoading, setIsPreviewLoading] = useState(false);
-  
+
   // At the top of your component
   useEffect(() => {
     console.log('Selected categories updated:', selectedCategories);
@@ -51,7 +51,7 @@ function Home() {
           name: 'urlblock',
           version: 1
         };
-        
+
         const cloudFunction = falcon.cloudFunction(config);
         const hostGroupsResponse = await cloudFunction.path('/urlblock').get();
 
@@ -129,10 +129,10 @@ function Home() {
         try {
           const objectKey = category;
           console.log(`Fetching URLs for category: ${category}, key: ${objectKey}`);
-          
+
           const record = await collection.read(objectKey);
           console.log(`Record for ${category}:`, record);
-          
+
           // Access the domain directly from the record
           if (record && record.domain) {
             return record.domain;
@@ -218,7 +218,7 @@ function Home() {
         name: 'urlblock',
         version: 1
       };
-      
+
       const cloudFunction = falcon.cloudFunction(config);
       const response = await cloudFunction.path('/create-rule').post({
         hostGroupId: selectedHostGroup,
@@ -230,7 +230,7 @@ function Home() {
 
       // Get host group name
       const hostGroupName = hostGroups.find(g => g.id === selectedHostGroup)?.name;
-      
+
       // Create relationship in collection for each selected category
       const relationshipPromises = selectedCategories.map(category => {
         const relationshipData = {
@@ -273,7 +273,7 @@ function Home() {
   const validateRelationshipData = (data) => {
     const requiredFields = ['category_name', 'rule_group_id', 'host_group_id'];
     const missingFields = requiredFields.filter(field => !data[field]);
-    
+
     if (missingFields.length > 0) {
       throw new Error(`Missing required fields: ${missingFields.join(', ')}`);
     }
@@ -311,7 +311,7 @@ function Home() {
       collection: 'relationship'
     });
 
-    const updatePromises = updates.map(({ key, data }) => 
+    const updatePromises = updates.map(({ key, data }) =>
       relationshipCollection.write(key, data)
     );
 
@@ -349,7 +349,7 @@ function Home() {
               height: '40px',
               lineHeight: '40px',
               border: '1px solid #B8B7BD',
-              borderRadius: '0'  
+              borderRadius: '0'
             }}
           />
         </div>
@@ -368,7 +368,7 @@ function Home() {
               height: '40px',
               lineHeight: '40px',
               border: '1px solid #B8B7BD',
-              borderRadius: '0'  
+              borderRadius: '0'
             }}
           >
             <option value="">Select</option>
@@ -393,7 +393,7 @@ function Home() {
             'min-width': '120px'
           }}
         >
-          Preview URLs
+          Preview Domains
         </sl-button>
 
         <sl-button
@@ -420,7 +420,7 @@ function Home() {
             Add custom categories
           </Link>
         </div>
-        <div 
+        <div
           className="grid grid-cols-4 gap-x-6 gap-y-2 max-h-[400px] overflow-y-auto p-4"
           style={{
             border: '1px solid #B8B7BD',
@@ -443,14 +443,14 @@ function Home() {
                     if (e.target.checked) {
                       setSelectedCategories(prev => [...prev, category]);
                     } else {
-                      setSelectedCategories(prev => 
+                      setSelectedCategories(prev =>
                         prev.filter(c => c !== category)
                       );
                     }
                   }}
                   className="h-4 w-4 text-gray-600 border-gray-300 focus:ring-0"
                 />
-                <label 
+                <label
                   htmlFor={`category-${category}`}
                   className="text-sm text-gray-700 cursor-pointer select-none"
                 >


### PR DESCRIPTION
This PR updates the terminology in the documentation and code to replace 'URLs' with 'domains' for consistency and clarity.