### PR TITLE
Remove unnecessary Go entries from .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,3 @@
 # For Python functions
 .venv/
 __pycache__/
-
-# For Go functions
-go.sum


### PR DESCRIPTION
This project only contains Python functions, so Go-specific ignore patterns are not needed.

## Changes
- Removed `# For Go functions` section
- Removed `go.sum` entry

The updated .gitignore now only includes patterns relevant to this project's Python-based functions.

cc: @CrowdStrike/Foundry