### PR TITLE
Add dual-strategy navigation for E2E tests

### DIFF
--- a/e2e/src/pages/CategoryBlockingPage.ts
+++ b/e2e/src/pages/CategoryBlockingPage.ts
@@ -156,8 +156,21 @@ export class CategoryBlockingPage extends BasePage {
 
       const openAppButton = this.page.getByRole('button', { name: 'Open app' });
       await openAppButton.waitFor({ state: 'visible', timeout: 10000 });
+
+      // Set up response listener BEFORE clicking to capture the page entity response
+      const pageEntityResponse = this.page.waitForResponse(
+        (resp) => resp.url().includes('/api2/ui-extensions/entities/pages/v1'),
+        { timeout: 15000 }
+      );
       await openAppButton.click();
       this.logger.success('Clicked "Open app" button from App Catalog');
+
+      // Wait for the page entity response and check for 404
+      const response = await pageEntityResponse;
+      if (response.status() === 404) {
+        this.logger.warn('Page entity returned 404, retrying with reload...');
+        await this.retryPageLoadAfter404();
+      }
 
       const iframe = this.page.locator('iframe');
       await iframe.waitFor({ state: 'visible', timeout: 30000 });
@@ -166,6 +179,28 @@ export class CategoryBlockingPage extends BasePage {
     } catch (e) {
       this.logger.warn(`"Open app" button not available: ${(e as Error).message}`);
       return false;
+    }
+  }
+
+  /**
+   * Retry page load after a 404 on the page entity endpoint.
+   * The service sometimes needs a moment to register newly deployed pages.
+   */
+  private async retryPageLoadAfter404(maxRetries = 3): Promise<void> {
+    for (let attempt = 1; attempt <= maxRetries; attempt++) {
+      const retryResponse = this.page.waitForResponse(
+        (resp) => resp.url().includes('/api2/ui-extensions/entities/pages/v1'),
+        { timeout: 15000 }
+      );
+      await this.page.reload();
+      await this.page.waitForLoadState('domcontentloaded');
+
+      const response = await retryResponse;
+      if (response.status() !== 404) {
+        this.logger.success(`Page entity returned ${response.status()} on retry ${attempt}`);
+        return;
+      }
+      this.logger.warn(`Page entity still 404 on retry ${attempt}/${maxRetries}`);
     }
   }
 

--- a/e2e/src/pages/CategoryBlockingPage.ts
+++ b/e2e/src/pages/CategoryBlockingPage.ts
@@ -36,7 +36,7 @@ export class CategoryBlockingPage extends BasePage {
           await this.page.reload({ waitUntil: 'networkidle' });
           await this.page.waitForTimeout(3000);
         }
-        await expect(this.page.locator('iframe')).toBeVisible({ timeout: 20000 });
+        await expect(this.page.locator('iframe[name="portal"]')).toBeVisible({ timeout: 20000 });
         iframeVisible = true;
       } catch (e) {
         this.logger.warn(`Iframe not visible on attempt ${attempt + 1}`);
@@ -48,7 +48,7 @@ export class CategoryBlockingPage extends BasePage {
     this.logger.success('App iframe is visible');
 
     // Verify app content loaded
-    const iframe = this.page.frameLocator('iframe');
+    const iframe = this.page.frameLocator('iframe[name="portal"]');
     const heading = iframe.getByRole('heading', { name: /Category Blocking/i });
 
     await expect(heading).toBeVisible({ timeout: 30000 });
@@ -172,7 +172,7 @@ export class CategoryBlockingPage extends BasePage {
         await this.retryPageLoadAfter404();
       }
 
-      const iframe = this.page.locator('iframe');
+      const iframe = this.page.locator('iframe[name="portal"]');
       await iframe.waitFor({ state: 'visible', timeout: 30000 });
       await this.verifyPageLoaded();
       return true;
@@ -231,7 +231,7 @@ export class CategoryBlockingPage extends BasePage {
   async createCustomCategory(categoryName: string, domains: string): Promise<void> {
     return this.withTiming(
       async () => {
-        const iframe = this.page.frameLocator('iframe');
+        const iframe = this.page.frameLocator('iframe[name="portal"]');
 
         // Click Custom Categories tab
         const customCategoriesTab = iframe.locator('sl-tab:has-text("Custom Categories") a').first();

--- a/e2e/src/pages/CategoryBlockingPage.ts
+++ b/e2e/src/pages/CategoryBlockingPage.ts
@@ -65,7 +65,12 @@ export class CategoryBlockingPage extends BasePage {
       async () => {
         this.logger.info(`Navigating to installed app '${appName}'`);
 
-        // Navigate via Custom Apps menu
+        // Strategy 1: Try "Open app" from the App Catalog detail page
+        const openedViaCatalog = await this.tryOpenAppViaCatalog(appName);
+        if (openedViaCatalog) return;
+
+        // Strategy 2: Fall back to Custom Apps menu navigation
+        this.logger.info('Falling back to Custom Apps menu navigation');
         await this.navigateToPath('/foundry/home', 'Foundry home page');
         await this.page.waitForLoadState('networkidle');
 
@@ -131,6 +136,37 @@ export class CategoryBlockingPage extends BasePage {
       },
       `Navigate to ${appName} app`
     );
+  }
+
+  /**
+   * Try to open the app via the "Open app" button on its App Catalog detail page.
+   * Returns true if successful, false if the button wasn't available.
+   */
+  private async tryOpenAppViaCatalog(appName: string): Promise<boolean> {
+    try {
+      this.logger.info('Trying to open app via App Catalog "Open app" button');
+      const baseUrl = this.getBaseURL();
+      const filterParam = encodeURIComponent(`name:~'${appName}'`);
+      await this.page.goto(`${baseUrl}/foundry/app-catalog?filter=${filterParam}`);
+      await this.page.waitForLoadState('domcontentloaded');
+
+      const appLink = this.page.getByRole('link', { name: appName, exact: true });
+      await appLink.waitFor({ state: 'visible', timeout: 15000 });
+      await appLink.click();
+
+      const openAppButton = this.page.getByRole('button', { name: 'Open app' });
+      await openAppButton.waitFor({ state: 'visible', timeout: 10000 });
+      await openAppButton.click();
+      this.logger.success('Clicked "Open app" button from App Catalog');
+
+      const iframe = this.page.locator('iframe');
+      await iframe.waitFor({ state: 'visible', timeout: 30000 });
+      await this.verifyPageLoaded();
+      return true;
+    } catch (e) {
+      this.logger.warn(`"Open app" button not available: ${(e as Error).message}`);
+      return false;
+    }
   }
 
   /**

--- a/e2e/tests/foundry.spec.ts
+++ b/e2e/tests/foundry.spec.ts
@@ -46,7 +46,7 @@ test.describe('Category Blocking App E2E Tests', () => {
       await categoryBlockingPage.navigateToInstalledApp();
 
       // Verify iframe is present
-      const iframe = categoryBlockingPage.page.locator('iframe');
+      const iframe = categoryBlockingPage.page.locator('iframe[name="portal"]');
       await expect(iframe).toBeVisible({ timeout: 15000 });
 
       logger.success('Category Blocking app iframe loaded successfully');
@@ -58,7 +58,7 @@ test.describe('Category Blocking App E2E Tests', () => {
       await categoryBlockingPage.navigateToInstalledApp();
 
       // Get the iframe
-      const iframe = page.frameLocator('iframe');
+      const iframe = page.frameLocator('iframe[name="portal"]');
 
       // Wait for and verify main heading is visible
       const heading = iframe.locator('h1:has-text("Category Blocking")');
@@ -78,7 +78,7 @@ test.describe('Category Blocking App E2E Tests', () => {
     test('should verify all navigation tabs are present', async ({ page }) => {
       await categoryBlockingPage.navigateToInstalledApp();
 
-      const iframe = page.frameLocator('iframe');
+      const iframe = page.frameLocator('iframe[name="portal"]');
 
       // Wait for navigation to be present
       await expect(iframe.locator('h1:has-text("Category Blocking")')).toBeVisible({ timeout: 15000 });
@@ -107,7 +107,7 @@ test.describe('Category Blocking App E2E Tests', () => {
     test('should click Custom Categories tab and verify navigation', async ({ page }) => {
       await categoryBlockingPage.navigateToInstalledApp();
 
-      const iframe = page.frameLocator('iframe');
+      const iframe = page.frameLocator('iframe[name="portal"]');
 
       // Wait for app to load
       await expect(iframe.locator('h1:has-text("Category Blocking")')).toBeVisible({ timeout: 15000 });
@@ -126,7 +126,7 @@ test.describe('Category Blocking App E2E Tests', () => {
     test('should click Domain Analytics tab and verify navigation', async ({ page }) => {
       await categoryBlockingPage.navigateToInstalledApp();
 
-      const iframe = page.frameLocator('iframe');
+      const iframe = page.frameLocator('iframe[name="portal"]');
 
       // Wait for app to load
       await expect(iframe.locator('h1:has-text("Category Blocking")')).toBeVisible({ timeout: 15000 });
@@ -145,7 +145,7 @@ test.describe('Category Blocking App E2E Tests', () => {
     test('should click Firewall Rules tab and verify navigation', async ({ page }) => {
       await categoryBlockingPage.navigateToInstalledApp();
 
-      const iframe = page.frameLocator('iframe');
+      const iframe = page.frameLocator('iframe[name="portal"]');
 
       // Wait for app to load
       await expect(iframe.locator('h1:has-text("Category Blocking")')).toBeVisible({ timeout: 15000 });
@@ -164,7 +164,7 @@ test.describe('Category Blocking App E2E Tests', () => {
     test('should click Relationship Graph tab and verify navigation', async ({ page }) => {
       await categoryBlockingPage.navigateToInstalledApp();
 
-      const iframe = page.frameLocator('iframe');
+      const iframe = page.frameLocator('iframe[name="portal"]');
 
       // Wait for app to load
       await expect(iframe.locator('h1:has-text("Category Blocking")')).toBeVisible({ timeout: 15000 });
@@ -183,7 +183,7 @@ test.describe('Category Blocking App E2E Tests', () => {
     test('should verify all tabs are clickable in sequence', async ({ page }) => {
       await categoryBlockingPage.navigateToInstalledApp();
 
-      const iframe = page.frameLocator('iframe');
+      const iframe = page.frameLocator('iframe[name="portal"]');
 
       // Wait for app to load
       await expect(iframe.locator('h1:has-text("Category Blocking")')).toBeVisible({ timeout: 15000 });
@@ -217,11 +217,11 @@ test.describe('Category Blocking App E2E Tests', () => {
       await categoryBlockingPage.navigateToInstalledApp();
 
       // Verify iframe is present and visible
-      const iframe = page.locator('iframe');
+      const iframe = page.locator('iframe[name="portal"]');
       await expect(iframe).toBeVisible({ timeout: 15000 });
 
       // Get the iframe locator for content checks
-      const iframeContent = page.frameLocator('iframe');
+      const iframeContent = page.frameLocator('iframe[name="portal"]');
 
       // Verify main content loaded
       const heading = iframeContent.locator('h1:has-text("Category Blocking")');


### PR DESCRIPTION
E2E tests now try the App Catalog "Open app" button first when navigating to the installed app. This is faster and more reliable than the Custom Apps sidebar menu, which sometimes requires multiple page refreshes before the app entry appears. If the catalog navigation encounters a 404 on the page entity endpoint (which happens when the service hasn't registered a newly deployed page yet), it automatically retries with page reloads. If the "Open app" button isn't available at all, the existing Custom Apps menu retry loop is used as a fallback.

This dual-strategy pattern with 404 retry was proven reliable in foundry-sample-logscale PR #26, and has passed 3 consecutive CI runs across all sample apps.