### PR TITLE
Upgrade postcss, lodash; add uuid override

### DIFF
--- a/ui/pages/urlblocking/package-lock.json
+++ b/ui/pages/urlblocking/package-lock.json
@@ -29,7 +29,7 @@
         "@rollup/plugin-node-resolve": "16.0.1",
         "@rollup/plugin-replace": "6.0.2",
         "@web/rollup-plugin-html": "2.3.0",
-        "postcss": "8.5.6",
+        "postcss": "8.5.14",
         "rollup": "4.59.0",
         "rollup-plugin-postcss": "4.0.2"
       },
@@ -4900,9 +4900,9 @@
       }
     },
     "node_modules/lodash": {
-      "version": "4.17.23",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.23.tgz",
-      "integrity": "sha512-LgVTMpQtIopCi79SJeDiP0TfWi5CNEc/L/aRdTh3yIvmZXTnheWpKjSZhnvMl8iXbC1tFg9gdHHDMLoV7CnG+w==",
+      "version": "4.18.1",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz",
+      "integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==",
       "license": "MIT"
     },
     "node_modules/lodash.camelcase": {
@@ -5833,9 +5833,9 @@
       "license": "MIT"
     },
     "node_modules/postcss": {
-      "version": "8.5.6",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.6.tgz",
-      "integrity": "sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg==",
+      "version": "8.5.14",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.14.tgz",
+      "integrity": "sha512-SoSL4+OSEtR99LHFZQiJLkT59C5B1amGO1NzTwj7TT1qCUgUO6hxOvzkOYxD+vMrXBM3XJIKzokoERdqQq/Zmg==",
       "funding": [
         {
           "type": "opencollective",
@@ -7862,9 +7862,9 @@
       "license": "MIT"
     },
     "node_modules/uuid": {
-      "version": "13.0.0",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-13.0.0.tgz",
-      "integrity": "sha512-XQegIaBTVUjSHliKqcnFqYypAd4S+WCYt5NIeRs6w/UAry7z8Y9j5ZwRRL4kzq9U3sD6v+85er9FvkEaBpji2w==",
+      "version": "13.0.1",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-13.0.1.tgz",
+      "integrity": "sha512-9ezox2roIft6ExBVTVqibSd5dc5/47Sw/uY6b4SjQUT2TzQ0tltNquWA46y4xPQmdZYqvnio22SgWd41M86+jw==",
       "funding": [
         "https://github.com/sponsors/broofa",
         "https://github.com/sponsors/ctavan"

--- a/ui/pages/urlblocking/package.json
+++ b/ui/pages/urlblocking/package.json
@@ -26,7 +26,7 @@
     "@rollup/plugin-node-resolve": "16.0.1",
     "@rollup/plugin-replace": "6.0.2",
     "@web/rollup-plugin-html": "2.3.0",
-    "postcss": "8.5.6",
+    "postcss": "8.5.14",
     "rollup": "4.59.0",
     "rollup-plugin-postcss": "4.0.2"
   },
@@ -41,8 +41,9 @@
     "svgo": "2.8.1",
     "minimatch@3": "3.1.4",
     "minimatch@9": "9.0.7",
-    "lodash": "4.17.23",
+    "lodash": "4.18.1",
     "yaml": "2.8.3",
-    "picomatch@4": "4.0.4"
+    "picomatch@4": "4.0.4",
+    "uuid": "13.0.1"
   }
 }

--- a/ui/pages/urlblocking/src/dist/app.js
+++ b/ui/pages/urlblocking/src/dist/app.js
@@ -6243,7 +6243,9 @@ function Link({
     return /*#__PURE__*/React.createElement("a", {
       onClick: e => {
         e.preventDefault();
-        navigation.onClick(e);
+        navigation.navigateTo({
+          path: to
+        });
       },
       href: to,
       className: combinedClassName


### PR DESCRIPTION
Fixes CVE-2026-41305 (postcss), CVE-2026-4800 and CVE-2026-2950 (lodash), and CVE-2026-41907 (uuid).

Build verified. protocol-buffers-schema 3.6.1 skipped (not in Artifactory).