### PR TITLE
Upgrade foundry-js to 0.22.0, foundry-playwright to 0.5.3, foundry-function to 1.1.4

### DIFF
--- a/e2e/package-lock.json
+++ b/e2e/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.0.0",
       "license": "MIT",
       "devDependencies": {
-        "@crowdstrike/foundry-playwright": "0.5.1",
+        "@crowdstrike/foundry-playwright": "0.5.3",
         "@types/node": "25.6.0"
       },
       "engines": {
@@ -17,9 +17,9 @@
       }
     },
     "node_modules/@crowdstrike/foundry-playwright": {
-      "version": "0.5.1",
-      "resolved": "https://registry.npmjs.org/@crowdstrike/foundry-playwright/-/foundry-playwright-0.5.1.tgz",
-      "integrity": "sha512-aB74uvvvfrOkHvy3jVfpeO3JPOjPdNHuMR+bUZyqUknFtZ4jBtquQMGWumspbXS+P78vDuI8c8BTVilnI2sscA==",
+      "version": "0.5.3",
+      "resolved": "https://registry.npmjs.org/@crowdstrike/foundry-playwright/-/foundry-playwright-0.5.3.tgz",
+      "integrity": "sha512-sB0Oz0MkgO4bOxbjx0FpQDAsQwTMCP4ndSjdrXViiFPKjLpmbAFKgY5A/D47GhTxYcBJQ3XxNryu7gcwEYDwSA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/e2e/package.json
+++ b/e2e/package.json
@@ -15,7 +15,7 @@
     "node": ">=22.0.0"
   },
   "devDependencies": {
-    "@crowdstrike/foundry-playwright": "0.5.1",
+    "@crowdstrike/foundry-playwright": "0.5.3",
     "@types/node": "25.6.0"
   }
 }

--- a/functions/urlblock/requirements.txt
+++ b/functions/urlblock/requirements.txt
@@ -1,3 +1,3 @@
-crowdstrike-foundry-function==1.1.3
+crowdstrike-foundry-function==1.1.4
 crowdstrike-falconpy
 pytz

--- a/ui/pages/urlblocking/package-lock.json
+++ b/ui/pages/urlblocking/package-lock.json
@@ -10,7 +10,7 @@
       "license": "MIT",
       "dependencies": {
         "@crowdstrike/falcon-shoelace": "0.4.0",
-        "@crowdstrike/foundry-js": "0.21.0",
+        "@crowdstrike/foundry-js": "0.22.0",
         "@crowdstrike/tailwind-toucan-base": "5.0.0",
         "@shoelace-style/shoelace": "2.20.1",
         "d3": "7.9.0",
@@ -429,14 +429,14 @@
       "license": "MIT"
     },
     "node_modules/@crowdstrike/foundry-js": {
-      "version": "0.21.0",
-      "resolved": "https://registry.npmjs.org/@crowdstrike/foundry-js/-/foundry-js-0.21.0.tgz",
-      "integrity": "sha512-anhEJJQXSGnpwOMhyYquXyLRQx1OdsqZ205xewLt3LUccz6hZpAJRFs6M+u/y4xzV8xXQ0+Y0Swz/JbHXXYLdQ==",
+      "version": "0.22.0",
+      "resolved": "https://registry.npmjs.org/@crowdstrike/foundry-js/-/foundry-js-0.22.0.tgz",
+      "integrity": "sha512-L0ztqCCG/Xg00or5mWz0LU26TRCSPD3LofNwx3WIh7njICFk/LK2vpb38WbyM6YHuyVgWly73a2M7+TFDXKa/g==",
       "license": "MIT",
       "dependencies": {
         "emittery": "1.2.0",
         "typescript-memoize": "1.1.1",
-        "uuid": "13.0.0"
+        "uuid": "13.0.1"
       },
       "engines": {
         "node": ">=22"
@@ -1859,9 +1859,9 @@
       "license": "ISC"
     },
     "node_modules/brace-expansion": {
-      "version": "5.0.5",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
-      "integrity": "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==",
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
+      "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -6541,9 +6541,9 @@
       }
     },
     "node_modules/protocol-buffers-schema": {
-      "version": "3.6.0",
-      "resolved": "https://registry.npmjs.org/protocol-buffers-schema/-/protocol-buffers-schema-3.6.0.tgz",
-      "integrity": "sha512-TdDRD+/QNdrCGCE7v8340QyuXd4kIWIgapsE2+n/SaGiSSbomYl4TjHlvIoCWRpE7wFt02EpB35VVA2ImcBVqw==",
+      "version": "3.6.1",
+      "resolved": "https://registry.npmjs.org/protocol-buffers-schema/-/protocol-buffers-schema-3.6.1.tgz",
+      "integrity": "sha512-VG2K63Igkiv9p76tk1lilczEK1cT+kCjKtkdhw1dQZV3k3IXJbd3o6Ho8b9zJZaHSnT2hKe4I+ObmX9w6m5SmQ==",
       "license": "MIT"
     },
     "node_modules/purgecss": {
@@ -7715,9 +7715,9 @@
       "license": "ISC"
     },
     "node_modules/tmp": {
-      "version": "0.2.5",
-      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.5.tgz",
-      "integrity": "sha512-voyz6MApa1rQGUxT3E+BK7/ROe8itEx7vD8/HEvt4xwXucvQ5G5oeEiHkmHZJuBO21RpOf+YYm9MOivj709jow==",
+      "version": "0.2.7",
+      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.7.tgz",
+      "integrity": "sha512-e0votIpp4Uo2AJYSzVHV6xCcawuiez3DzqDAbrTc3YxBkplN6e+dM13ZeIcZnDg/QpSuU2zfZ3rzwY8ukEnaXw==",
       "license": "MIT",
       "engines": {
         "node": ">=14.14"

--- a/ui/pages/urlblocking/package.json
+++ b/ui/pages/urlblocking/package.json
@@ -7,7 +7,7 @@
   "directories": {},
   "dependencies": {
     "@crowdstrike/falcon-shoelace": "0.4.0",
-    "@crowdstrike/foundry-js": "0.21.0",
+    "@crowdstrike/foundry-js": "0.22.0",
     "@crowdstrike/tailwind-toucan-base": "5.0.0",
     "@shoelace-style/shoelace": "2.20.1",
     "d3": "7.9.0",
@@ -44,6 +44,9 @@
     "lodash": "4.18.1",
     "yaml": "2.8.3",
     "picomatch@4": "4.0.4",
-    "uuid": "13.0.1"
+    "uuid": "13.0.1",
+    "tmp": "0.2.7",
+    "brace-expansion@5": "5.0.6",
+    "protocol-buffers-schema": "3.6.1"
   }
 }


### PR DESCRIPTION
- @crowdstrike/foundry-js 0.21.0 → 0.22.0 (latest)
- @crowdstrike/foundry-playwright 0.5.1 → 0.5.3 (latest)
- crowdstrike-foundry-function 1.1.3 → 1.1.4
- Added overrides for tmp, brace-expansion, protocol-buffers-schema CVEs
- 0 vulnerabilities remaining