### PR TITLE
fix: skip node setup when rebuild not needed

### DIFF
--- a/.github/workflows/rebuild.yml
+++ b/.github/workflows/rebuild.yml
@@ -17,10 +17,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8  # v6.0.1
-      - name: Setup Node
-        uses: actions/setup-node@395ad3262231945c25e8478fd5baf05154b1d79f  # v6.1.0
-        with:
-          node-version: 22
       - name: Check if rebuild needed
         id: check
         run: |
@@ -39,6 +35,11 @@ jobs:
             echo "Dependency changes detected:"
             echo "$CHANGES"
           fi
+      - name: Setup Node
+        if: steps.check.outputs.skip != 'true'
+        uses: actions/setup-node@395ad3262231945c25e8478fd5baf05154b1d79f  # v6.1.0
+        with:
+          node-version: 22
       - name: Install dependencies
         if: steps.check.outputs.skip != 'true'
         run: npm ci

--- a/.github/workflows/rebuild.yml
+++ b/.github/workflows/rebuild.yml
@@ -13,7 +13,7 @@ jobs:
       contents: write # for peter-evans/create-pull-request to create branch
       pull-requests: write # for peter-evans/create-pull-request to create a PR
     name: Rebuild
-    if: github.repository == 'CrowdStrike/foundry-sample-url-filtering'
+    if: github.repository == 'CrowdStrike/foundry-sample-category-blocking'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8  # v6.0.1


### PR DESCRIPTION
Moves the rebuild check before setup-node so that when no dependency changes are detected, node setup is skipped entirely.